### PR TITLE
Update WPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
                 "justintadlock/hybrid-core" : "5.0.x-dev"
         },
 	"require-dev": {
-		"wp-coding-standards/wpcs": "^0.14.1",
+		"wp-coding-standards/wpcs": "^1.0.0",
 		"wimg/php-compatibility": "^8.2"
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -47,7 +47,6 @@
 
 	<!-- Include the WordPress ruleset, with exclusions. -->
 	<rule ref="WordPress">
-		<config name="installed_paths" value="vendor/wp-coding-standards/wpcs" />
 		<!-- Allow short open tags. -->
 		<exclude name="Generic.PHP.DisallowShortOpenTag.EchoFound" />
 	</rule>


### PR DESCRIPTION
[WPCS was updated to version 1.0.0](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/CHANGELOG.md#100---2018-07-25).